### PR TITLE
Requests endpoints + sandbox URL

### DIFF
--- a/lib/Uber.js
+++ b/lib/Uber.js
@@ -6,17 +6,19 @@ var resources = {
   Estimates: require('./resources/Estimates'),
   Products: require('./resources/Products'),
   Promotions: require('./resources/Promotions'),
-  User: require('./resources/User')
+  User: require('./resources/User'),
+  Requests: require('./resources/Requests')
 };
 
 function Uber(options) {
+  this.sandbox = options.sandbox;
   this.defaults = {
     client_id: options.client_id,
     client_secret: options.client_secret,
     server_token: options.server_token,
     redirect_uri: options.redirect_uri,
     name: options.name,
-    base_url: 'https://api.uber.com/',
+    base_url: this.sandbox ? 'https://sandbox-api.uber.com/' : 'https://api.uber.com/',
     authorize_url: 'https://login.uber.com/oauth/authorize',
     access_token_url: 'https://login.uber.com/oauth/token'    
   };
@@ -92,6 +94,56 @@ Uber.prototype.authorization = function (options, callback) {
   });
 
   return self;
+};
+
+Uber.prototype.post = function (options, callback) {
+	return this.putPostHelper(options, callback, 'post');
+};
+
+Uber.prototype.put = function (options, callback) {
+	return this.putPostHelper(options, callback, 'put');
+};
+
+Uber.prototype.putPostHelper = function(options, callback, method) {
+
+  if (!options.version) {
+    options.version = 'v1'
+  }
+
+  var url = this.defaults.base_url + options.version + '/' + options.url + '?' 
+    , accessToken = (this.access_token) ? this.access_token : null;
+
+  if (!accessToken) {
+    return callback(new Error('Invalid access token'));
+  }
+
+  var localCallback = function (err, data, res) {	  // shared callback between put and post requests
+    if (err) {
+      callback(err);
+    } else {
+      callback(null, res);
+    }
+  };
+
+  var params = {
+    url: url,
+    json: true,
+    headers: {
+    	'Content-Type': 'application/json',
+    	'Authorization' : 'Bearer '+accessToken
+  	},
+  	body : options.params
+  };
+
+  if ( method == 'post' ) {
+  	request.post(params, localCallback);
+  } else if ( method == 'put' ) {
+  	request.put(params, localCallback);
+  } else {
+  	localCallback(new Error('Unrecognized HTTP Method'));
+  }
+
+  return this;
 };
 
 Uber.prototype.get = function (options, callback) {

--- a/lib/resources/Requests.js
+++ b/lib/resources/Requests.js
@@ -1,0 +1,33 @@
+function Products(uber) {
+  this._uber = uber;
+  this.path = '';	// defined in each method instead
+}
+
+module.exports = Products;
+
+Products.prototype.requestRide = function (parameters, callback) {
+
+  if ( !parameters.start_latitude || !parameters.start_longitude || !parameters.product_id ) {
+  	return callback(new Error('Invalid parameters'));
+  }
+	
+  var accessToken = this._uber.access_token;
+  if (!accessToken) {
+    return callback(new Error('Invalid access token'));
+  }
+
+  var query = { url: 'requests', params: parameters, access_token: accessToken };
+  return this._uber.post(query, callback);
+};
+
+Products.prototype.estimate = function (parameters, callback) {
+
+  var accessToken = this._uber.access_token;
+  if (!accessToken) {
+    return callback(new Error('Invalid access token'));
+  }
+  var query = { url: 'requests/estimate', params: parameters, access_token: accessToken };
+  return this._uber.post(query, callback);
+};
+
+


### PR DESCRIPTION
- Adds support for wrappers of `POST /requests` and `POST /requests/estimate`.
- Adds support for making POST and PUT requests
- Can specify `options.sandbox` to hit sandbox servers. This is recommended if you are making a request, unless you really need a ride ;)