### PR TITLE
Added support for rate limit

### DIFF
--- a/lib/Uber.js
+++ b/lib/Uber.js
@@ -68,15 +68,17 @@ Uber.prototype._updateRateLimit = function(data) {
     if (!this.rate_limit_reset) {
         return;
     }
-    // console.log('Rate Limit', this.rate_limit);
-    // console.log('Rate Limit Remaining', this.rate_limit_remaining);
-    // console.log('Rate Limit Reset', this.rate_limit_date);
     if (today > this.rate_limit_date) {
         this.rate_limit_remaining = this.rate_limit;
     }
     if (this.rate_limit_remaining === 0) {
-        return new RateLimitError("Rate Limit Reached, will reset in " + this.rate_limit_reset_minutes_left + " mins");
+        return new RateLimitError("Rate Limit Reached, will reset in " + this.rate_limit_reset_minutes_left + " mins", data && data.hasOwnProperty('body')? data.body : null);
     }
+    // console.log('Rate Limit', this.rate_limit);
+    // console.log('Rate Limit Remaining', this.rate_limit_remaining);
+    // console.log('Rate Limit Reset', this.rate_limit_date);
+    // console.log('Rate Limit Reset Date', this.rate_limit);
+    // console.log('Rate Limit Reset Minutes Left', this.rate_limit_reset_minutes_left);
     return null;
 };
 
@@ -242,8 +244,10 @@ Uber.prototype.get = function get(options, callback) {
         url += '?' + qs.stringify(options.params);
     }
 
-    if (this.rate_limit === 0)
-        return callback(new RateLimitError("Rate Limit Reached"));
+    // If rate limit is zero, no point to make the request
+    if (this.rate_limit === 0) {
+        return callback(new RateLimitError("Rate Limit Reached, will reset in " + this.rate_limit_reset_minutes_left + " mins"));
+    }
 
     request.get({
         url: url,
@@ -257,12 +261,12 @@ Uber.prototype.get = function get(options, callback) {
         if (err || data.statusCode >= 400) {
             self._updateRateLimit(data);
             if (data.statusCode === 429 && res.code === 'rate_limited')
-                return callback(new RateLimitError("Rate Limit Reached"), res);
+                return callback(new RateLimitError("Rate Limit Reached"), data && data.hasOwnProperty('body') ? data.body : null);
             else
                 return callback((err ? err : data), res);
         } else {
-            self._updateRateLimit(data);
-            return callback(null, res);
+            var rate_err = self._updateRateLimit(data);
+            return callback(rate_err, res);
         }
     });
 

--- a/lib/Uber.js
+++ b/lib/Uber.js
@@ -2,6 +2,7 @@ var request = require('request');
 var qs = require('querystring');
 var OAuth = require('oauth');
 var util = require('util');
+var RateLimitError = require('./errors/RateLimitError');
 
 var resources = {
     Estimates: require('./resources/Estimates'),
@@ -24,7 +25,8 @@ function Uber(options) {
         base_url: this.sandbox ? 'https://sandbox-api.uber.com/' : 'https://api.uber.com/',
         authorize_url: 'https://login.uber.com/oauth/authorize',
         access_token_url: 'https://login.uber.com/oauth/token',
-        language: options.language ? options.language : 'en_US'
+        language: options.language ? options.language : 'en_US',
+        rate_limit: 2000
     };
 
     this.oauth2 = new OAuth.OAuth2(
@@ -39,10 +41,44 @@ function Uber(options) {
     this.access_token = options.access_token;
     this.refresh_token = options.refresh_token;
 
+    this.rate_limit = options.rate_limit;
+    this.rate_limit_remaining = options.rate_limit;
+    this.rate_limit_reset = null;
+
     this._initResources();
 }
 
 module.exports = Uber;
+
+Uber.prototype._updateRateLimit = function(data) {
+    var today = new Date();
+    if (data && data.headers && data.headers.hasOwnProperty('x-rate-limit-remaining')) {
+        this.rate_limit_remaining = parseInt(data.headers['x-rate-limit-remaining']); // Number of requests left in the rate limit window.
+    }
+    if (data && data.headers && data.headers.hasOwnProperty('x-rate-limit-limit')) {
+        this.rate_limit = parseInt(data.headers['x-rate-limit-limit']); // Total number of requests possible.
+    }
+    if (data && data.headers && data.headers.hasOwnProperty('x-rate-limit-reset')) {
+        this.rate_limit_reset = parseInt(data.headers['x-rate-limit-reset']); // Timestamp when the rate limit will reset.
+        this.rate_limit_reset_date = new Date(parseInt(data.headers['x-rate-limit-reset']) * 1000); // Timestamp when the rate limit will reset.
+        var diffMs = (this.rate_limit_date - today); // milliseconds between now & Christmas
+        this.rate_limit_reset_minutes_left = Math.round(((diffMs % 86400000) % 3600000) / 60000); // minutes
+    }
+    // If we have no rate limit reset date
+    if (!this.rate_limit_reset) {
+        return;
+    }
+    // console.log('Rate Limit', this.rate_limit);
+    // console.log('Rate Limit Remaining', this.rate_limit_remaining);
+    // console.log('Rate Limit Reset', this.rate_limit_date);
+    if (today > this.rate_limit_date) {
+        this.rate_limit_remaining = this.rate_limit;
+    }
+    if (this.rate_limit_remaining === 0) {
+        return new RateLimitError("Rate Limit Reached, will reset in " + this.rate_limit_reset_minutes_left + " mins");
+    }
+    return null;
+};
 
 Uber.prototype._initResources = function() {
     for (var name in this.resources) {
@@ -117,19 +153,26 @@ Uber.prototype.put = function put(options, callback) {
 };
 
 Uber.prototype.modifierMethodExecute = function modifierMethodExecute(method, params, callback) {
+    var self = this;
+    function interceptCallback(err, data, res) {
+        var rate_err = self._updateRateLimit(data);
+        callback(rate_err ? rate_err : err, data, res);
+    }
     switch (method) {
         case 'delete':
-            request.delete(params, callback);
+            request.delete(params, interceptCallback);
             break;
         case 'post':
-            request.post(params, callback);
+            request.post(params, interceptCallback);
             break;
         case 'put':
-            request.put(params, callback);
+            request.put(params, interceptCallback);
             break;
         case 'patch':
-            request.patch(params, callback);
+            request.patch(params, interceptCallback);
             break;
+        default:
+            return callback(new Error("Unknown Method"));
     }
 };
 
@@ -187,17 +230,20 @@ Uber.prototype.createAccessHeader = function createAccessHeader(server_token) {
 };
 
 Uber.prototype.get = function get(options, callback) {
+    var self = this;
     var access_type = this.createAccessHeader(options.server_token);
     if (!access_type) {
         return callback(new Error('Invalid access token'), 'A valid access token is required for this request');
     }
     var url = this.getRequestURL(options.version, options.url);
 
-
     // add all further option params
     if (options.params) {
         url += '?' + qs.stringify(options.params);
     }
+
+    if (this.rate_limit === 0)
+        return callback(new RateLimitError("Rate Limit Reached"));
 
     request.get({
         url: url,
@@ -209,8 +255,13 @@ Uber.prototype.get = function get(options, callback) {
         }
     }, function(err, data, res) {
         if (err || data.statusCode >= 400) {
-            return callback((err ? err : data), res);
+            self._updateRateLimit(data);
+            if (data.statusCode === 429 && res.code === 'rate_limited')
+                return callback(new RateLimitError("Rate Limit Reached"), res);
+            else
+                return callback((err ? err : data), res);
         } else {
+            self._updateRateLimit(data);
             return callback(null, res);
         }
     });
@@ -221,7 +272,7 @@ Uber.prototype.get = function get(options, callback) {
 Uber.prototype.clearTokens = function clearTokens() {
     this.access_token = null;
     this.refresh_token = null;
-}
+};
 
 Uber.prototype.isNumeric = function isNumeric(input) {
     return (!input || isNaN(input)) ? false : true;

--- a/lib/errors/RateLimitError.js
+++ b/lib/errors/RateLimitError.js
@@ -1,12 +1,12 @@
 var util = require('util');
 
-var RateLimitError = function(message, extra) {
+var CustomError = function RateLimitError(message, extra) {
   Error.captureStackTrace(this, this.constructor);
   this.name = this.constructor.name;
   this.message = message;
   this.extra = extra;
 };
 
-util.inherits(RateLimitError, Error);
+util.inherits(CustomError, Error);
 
-module.exports = RateLimitError;
+module.exports = CustomError;

--- a/lib/errors/RateLimitError.js
+++ b/lib/errors/RateLimitError.js
@@ -1,0 +1,12 @@
+var util = require('util');
+
+var RateLimitError = function(message, extra) {
+  Error.captureStackTrace(this, this.constructor);
+  this.name = this.constructor.name;
+  this.message = message;
+  this.extra = extra;
+};
+
+util.inherits(RateLimitError, Error);
+
+module.exports = RateLimitError;


### PR DESCRIPTION
Added some simple rate limit handling.

I've noticed that rate limiting is active during sandbox mode, but they don't tell you how many requests you have left or what the limit is, so this was slightly more tricky to handle.

Essentially it just keeps track of the rate limit locally, and the rate limit reset date. If you've hit the rate limit it will return a specific node custom error RateLimitError, this makes it very easy to know if we should retry.

Some users will have requested an increase to the default rate limit, so I've also added the ability to set the initial rate limit when you create the Uber object.
